### PR TITLE
fix: 适配部分应用使用原生Gemini请求时url携带key参数导致报错

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -107,7 +107,14 @@ export class LoadBalancer extends DurableObject {
 				return new Response('Unauthorized', { status: 401, headers: fixCors({}).headers });
 			}
 		}
-		const targetUrl = `${BASE_URL}${pathname}${search}`;
+		
+		// Remove api key from query parameters if present
+		let targetUrl = `${BASE_URL}${pathname}${search}`;
+		if (search.includes('key=')) {
+			const urlObj = new URL(targetUrl);
+			urlObj.searchParams.delete('key');
+			targetUrl = urlObj.toString();
+		}
 
 		try {
 			const headers = new Headers();


### PR DESCRIPTION
- 检查 URL 查询参数中是否包含 'key='
- 如果存在，使用 URL 对象删除 'key' 参数
- 更新 targetUrl 为修改后的 URL 字符串