### PR TITLE
fix(auth): 为HOME_ACCESS_KEY解码cookie以避免401带有“ + ”和编码字符

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,8 +3,8 @@ export function getAuthKey(request: Request, sessionKey?: string): string | unde
     // 先查 cookie
     const cookie = request.headers.get('Cookie');
     if (cookie) {
-        const match = cookie.match(/auth-key=([^;]+)/);
-        if (match) return match[1];
+        const match = cookie.match(/(?:^|;\\s*)auth-key=([^;]+)/);
+        if (match) { try { return decodeURIComponent(match[1]); } catch { return match[1]; } }
     }
     // 再查 Authorization header
     const authHeader = request.headers.get('Authorization');


### PR DESCRIPTION
背景
- 当 HOME_ACCESS_KEY 包含 “+”（如 11234+）时，登录后管理面板内的管理 API（/api/keys, /api/keys/check    
等）均返回 401。移除 “+” 后恢复正常。

根因
- 登录时通过 hono/cookie 写入 auth-key，值会被 URL 编码（+ → %2B）。
- Durable Object 中 getAuthKey 使用正则从 Cookie 头直接取值，未做 URL 解码，比较时 %2B ≠ +，从而 401。  

修复
- src/auth.ts：对 auth-key 值执行 decodeURIComponent（带 try/catch 兜底），并增强了 Cookie 匹配的边界   
正则。

验证
- 在 Cloudflare 将 HOME_ACCESS_KEY 设为 11234+ 测试通过；其它被编码字符（空格、% 、/、中文等）也通过。  
- 对 Authorization: Bearer <HOME_ACCESS_KEY> 的认证无影响。

影响面
- 仅影响管理 API 认证；向后兼容，无破坏性改动。
